### PR TITLE
Fixed spamming of errors on token expiration

### DIFF
--- a/client/src/reducers/cabinetsReducer.js
+++ b/client/src/reducers/cabinetsReducer.js
@@ -47,11 +47,7 @@ export const initializeCabinets = () => async (dispatch) => {
     const cabinets = await cabinetsService.getCabinets();
     dispatch(setCabinets(cabinets));
   } catch (err) {
-    if (err.name === "AxiosError") {
-      dispatch(setError(err.response.data, "GET CABINETS"));
-    } else {
-      dispatch(setError(err, "GET CABINETS"));
-    }
+    dispatch(setError(err, "GET CABINETS"));
   }
 };
 

--- a/client/src/reducers/errorReducer.js
+++ b/client/src/reducers/errorReducer.js
@@ -87,7 +87,7 @@ export const createError = (err, area = "GENERAL") => {
     scope = "GENERAL";
   }
 
-  if (err.error?.message === "jwt expired") {
+  if (err.error === "token expired") {
     name = "JWT EXPIRED";
     message = "Your session has expired, please log in again";
     scope = "GENERAL";

--- a/client/src/reducers/itemsReducer.js
+++ b/client/src/reducers/itemsReducer.js
@@ -34,7 +34,7 @@ export const initializeItems = () => async (dispatch) => {
     const items = await itemsService.getItems();
     dispatch(setItems(items));
   } catch (err) {
-    dispatch(setError(err.message, "GET ITEMS"));
+    dispatch(setError(err, "GET ITEMS"));
   }
 };
 

--- a/client/src/reducers/userReducer.js
+++ b/client/src/reducers/userReducer.js
@@ -4,6 +4,7 @@ import { clearCabinets, initializeCabinets } from "./cabinetsReducer";
 import tokenHelper from "../services/tokenHelper";
 import { clearDrawers, initializeDrawers } from "./drawersReducer";
 import { clearItems, initializeItems } from "./itemsReducer";
+import { setError } from "./errorReducer";
 
 const LSUSERKEY = "PKInventoryUser";
 
@@ -46,10 +47,15 @@ export const initializeUser = () => async (dispatch) => {
   if (localUser) {
     const user = JSON.parse(localUser);
     tokenHelper.setToken(user.token);
-    dispatch(initializeCabinets());
-    dispatch(initializeDrawers());
-    dispatch(initializeItems());
-    dispatch(setUser(user));
+    try {
+      await loginService.checkToken();
+      dispatch(initializeCabinets());
+      dispatch(initializeDrawers());
+      dispatch(initializeItems());
+      dispatch(setUser(user));
+    } catch (err) {
+      dispatch(setError(err, "INITIALIZE USER"));
+    }
   } else {
     dispatch(clearUser());
     dispatch(clearCabinets());

--- a/client/src/services/login.js
+++ b/client/src/services/login.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import tokenHelper from "./tokenHelper";
 
 const url = "/api/login";
 
@@ -7,6 +8,11 @@ const login = async (credentials) => {
   return response.data;
 };
 
-const loginService = { login };
+const checkToken = async () => {
+  const response = await axios.get(url, tokenHelper.getConfig());
+  return response.data;
+};
+
+const loginService = { login, checkToken };
 
 export default loginService;

--- a/routers/login.js
+++ b/routers/login.js
@@ -2,6 +2,7 @@ const loginRouter = require("express").Router();
 const jwt = require("jsonwebtoken");
 const bcrypt = require("bcrypt");
 const User = require("../models/user");
+const middleware = require("../utils/middleware");
 
 loginRouter.post("/", async (req, res) => {
   const { username, password } = req.body;
@@ -32,10 +33,14 @@ loginRouter.post("/", async (req, res) => {
   const token = jwt.sign(
     { username: user.username, id: user._id },
     process.env.SECRET,
-    { expiresIn: "12h" }
+    { expiresIn: "12s" }
   );
 
   res.status(200).send({ token, username: user.username, admin: user.admin });
+});
+
+loginRouter.get("/", middleware.userExtractor, (req, res) => {
+  res.status(200).end();
 });
 
 module.exports = loginRouter;

--- a/tests/login_api.test.js
+++ b/tests/login_api.test.js
@@ -6,94 +6,159 @@ const helper = require("./test_helper");
 
 const api = supertest(app);
 
+const existingAdminUser = {
+  username: uuid(),
+  admin: true,
+  password: uuid(),
+};
 const existingUser = {
   username: uuid(),
-  admin: Math.random() > 0.5,
+  admin: false,
   password: uuid(),
 };
 beforeAll(async () => {
+  await helper.generateUser(existingAdminUser);
   await helper.generateUser(existingUser);
 }, 100000);
 
-describe("When some users exist, logging in with", () => {
-  test("valid credentials succeeds with 200, and returns a json payload with a token and a username", async () => {
-    const credentials = {
-      username: existingUser.username,
-      password: existingUser.password,
-    };
+describe("When some users exist", () => {
+  describe("loggin in with", () => {
+    test("valid credentials succeeds with 200, and returns a json payload with a token and a username", async () => {
+      const credentials = {
+        username: existingUser.username,
+        password: existingUser.password,
+      };
 
-    const response = await api
-      .post("/api/login")
-      .send(credentials)
-      .expect(200)
-      .expect("Content-Type", /application\/json/);
+      const response = await api
+        .post("/api/login")
+        .send(credentials)
+        .expect(200)
+        .expect("Content-Type", /application\/json/);
 
-    expect(response.body.token).toBeDefined();
-    expect(response.body.username).toEqual(credentials.username);
+      expect(response.body.token).toBeDefined();
+      expect(response.body.username).toEqual(credentials.username);
+    });
+
+    test("a missing username returns 400 and error message", async () => {
+      const credentials = {
+        password: existingUser.password,
+      };
+
+      const response = await api
+        .post("/api/login")
+        .send(credentials)
+        .expect(400)
+        .expect("Content-Type", /application\/json/);
+
+      expect(response.body.error).toEqual("username is required");
+    });
+    test("a missing password returns 400 and error message", async () => {
+      const credentials = {
+        username: existingUser.username,
+      };
+
+      const response = await api
+        .post("/api/login")
+        .send(credentials)
+        .expect(400)
+        .expect("Content-Type", /application\/json/);
+
+      expect(response.body.error).toEqual("password is required");
+    });
+    test("an invalid password returns 422 and error message", async () => {
+      const credentials = {
+        username: existingUser.username,
+        password: "wrongpassword",
+      };
+
+      const response = await api
+        .post("/api/login")
+        .send(credentials)
+        .expect(422)
+        .expect("Content-Type", /application\/json/);
+
+      expect(response.body.error).toEqual("invalid password");
+    });
+    test("a non-existing user returns 404 and error message", async () => {
+      const removedUser = {
+        username: uuid(),
+        admin: Math.random() > 0.5,
+        password: uuid(),
+      };
+
+      const savedUser = await helper.generateUser(removedUser);
+      await savedUser.deleteOne();
+
+      const credentials = {
+        username: removedUser.username,
+        password: removedUser.password,
+      };
+
+      const response = await api
+        .post("/api/login")
+        .send(credentials)
+        .expect(404)
+        .expect("Content-Type", /application\/json/);
+
+      expect(response.body.error).toEqual("user doesn't exist");
+    });
   });
+  describe("Checking token", () => {
+    test("Without a token returns 401 and a valid error message", async () => {
+      const response = await api
+        .get("/api/login")
+        .expect(401)
+        .expect("Content-Type", /application\/json/);
 
-  test("a missing username returns 400 and error message", async () => {
-    const credentials = {
-      password: existingUser.password,
-    };
+      expect(response.body.error).toContain(
+        "authorization token missing from request"
+      );
+    });
+    test("With a malformed token returns 400 and a valid error message", async () => {
+      const token = "abadtokenwhichdoesntmakesense";
 
-    const response = await api
-      .post("/api/login")
-      .send(credentials)
-      .expect(400)
-      .expect("Content-Type", /application\/json/);
+      const response = await api
+        .get("/api/login")
+        .set("Authorization", `Bearer ${token}`)
+        .expect(400)
+        .expect("Content-Type", /application\/json/);
 
-    expect(response.body.error).toEqual("username is required");
-  });
-  test("a missing password returns 400 and error message", async () => {
-    const credentials = {
-      username: existingUser.username,
-    };
+      expect(response.body.error).toContain("malformed token");
+    });
+    test("With a expired token returns 401 and a valid error message", async () => {
+      const token = await helper.getRandomAdminTokenFrom(
+        [existingUser, existingAdminUser],
+        0
+      );
 
-    const response = await api
-      .post("/api/login")
-      .send(credentials)
-      .expect(400)
-      .expect("Content-Type", /application\/json/);
+      const response = await api
+        .get("/api/login")
+        .set("Authorization", `Bearer ${token}`)
+        .expect(401)
+        .expect("Content-Type", /application\/json/);
 
-    expect(response.body.error).toEqual("password is required");
-  });
-  test("an invalid password returns 422 and error message", async () => {
-    const credentials = {
-      username: existingUser.username,
-      password: "wrongpassword",
-    };
-
-    const response = await api
-      .post("/api/login")
-      .send(credentials)
-      .expect(422)
-      .expect("Content-Type", /application\/json/);
-
-    expect(response.body.error).toEqual("invalid password");
-  });
-  test("a non-existing user returns 404 and error message", async () => {
-    const removedUser = {
-      username: uuid(),
-      admin: Math.random() > 0.5,
-      password: uuid(),
-    };
-
-    const savedUser = await helper.generateUser(removedUser);
-    await savedUser.deleteOne();
-
-    const credentials = {
-      username: removedUser.username,
-      password: removedUser.password,
-    };
-
-    const response = await api
-      .post("/api/login")
-      .send(credentials)
-      .expect(404)
-      .expect("Content-Type", /application\/json/);
-
-    expect(response.body.error).toEqual("user doesn't exist");
+      expect(response.body.error).toContain("token expired");
+    });
+    test("with an admin token succeeds with 200", async () => {
+      const token = await helper.getRandomAdminTokenFrom([
+        existingUser,
+        existingAdminUser,
+      ]);
+      await api
+        .get("/api/login")
+        .set("Authorization", `Bearer ${token}`)
+        .expect(200);
+    });
+    test("with a non admin token succeeds with 200", async () => {
+      const token = await helper.getRandomNonAdminTokenFrom([
+        existingUser,
+        existingAdminUser,
+      ]);
+      await api
+        .get("/api/login")
+        .set("Authorization", `Bearer ${token}`)
+        .expect(200);
+    });
   });
 });
 

--- a/tests/test_helper.js
+++ b/tests/test_helper.js
@@ -6,12 +6,16 @@ const Cabinet = require("../models/cabinet");
 const Drawer = require("../models/drawer");
 const Item = require("../models/item");
 
-const getTokenForUser = (user) => {
+const getTokenForUser = (user, expiresInS = -1) => {
   const userForToken = {
     username: user.username,
     id: user._id,
   };
-  return jwt.sign(userForToken, process.env.SECRET);
+  return jwt.sign(
+    userForToken,
+    process.env.SECRET,
+    expiresInS === -1 ? {} : { expiresIn: `${expiresInS}s` }
+  );
 };
 
 const generateUser = async (userData) => {
@@ -37,14 +41,14 @@ const getRandomUserOf = async (users, filter = () => true) => {
   return User.findOne({ username: userData.username });
 };
 
-const getRandomAdminTokenFrom = async (users) => {
+const getRandomAdminTokenFrom = async (users, expiresInS = -1) => {
   const user = await getRandomUserOf(users, (u) => u.admin);
-  return getTokenForUser(user);
+  return getTokenForUser(user, expiresInS);
 };
 
-const getRandomNonAdminTokenFrom = async (users) => {
+const getRandomNonAdminTokenFrom = async (users, expiresInS = -1) => {
   const user = await getRandomUserOf(users, (u) => !u.admin);
-  return getTokenForUser(user);
+  return getTokenForUser(user, expiresInS);
 };
 
 const getInvalidToken = async () => {

--- a/utils/middleware.js
+++ b/utils/middleware.js
@@ -64,6 +64,8 @@ const errorHandler = async (err, req, res, next) => {
       logger.error(`Unhandled Cast Error: ${err.message}`);
       res.status(400).send({ error: err.message });
     }
+  } else if (err.name === "TokenExpiredError") {
+    res.status(401).send({ error: "token expired" });
   } else {
     logger.error(`Unhandled Error: ${err}`);
     res.status(500).send({ error: err });


### PR DESCRIPTION
added get endpoint to login to check token
made error reporting of reducers consistant
when data is initialized, the new login check endpoint is hit first